### PR TITLE
Add MCP server endpoint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Endpoint serving and batch inference workloads.
 AI gateway and agent deployments.
 
 - [`openclaw`](./agents/openclaw/README.md) — deploy OpenClaw AI gateway on a CPU endpoint, connected to TokenFactory
+- [`mcp-server-endpoint`](./agents/mcp-server-endpoint/README.md) — run an MCP tool server on a CPU endpoint backed by Nebius TokenFactory
 
 ### 🧬 Life Science
 Domain-specific simulation and analysis workloads.

--- a/agents/mcp-server-endpoint/Dockerfile
+++ b/agents/mcp-server-endpoint/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ .
+EXPOSE 8000
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/agents/mcp-server-endpoint/README.md
+++ b/agents/mcp-server-endpoint/README.md
@@ -1,0 +1,148 @@
+---
+title: MCP Server on Serverless Endpoint
+category: agents
+type: endpoint
+runtime: cpu
+frameworks:
+  - fastapi
+  - mcp
+  - uvicorn
+keywords:
+  - mcp
+  - model-context-protocol
+  - serverless
+  - embeddings
+  - tokenfactory
+difficulty: intermediate
+---
+
+# MCP Server on Serverless Endpoint
+
+Run an MCP tool server as a CPU endpoint on Nebius Serverless.
+
+## What this example does
+
+Deploys a FastAPI server that speaks the Model Context Protocol over HTTP.
+It exposes an `embed` tool backed by Nebius TokenFactory (Qwen3-Embedding-8B).
+
+A local bridge script connects any MCP client to the remote endpoint over stdio.
+
+### Why this is useful
+
+Your tools run in the cloud, not on your machine.
+The endpoint starts in seconds and costs nothing when idle.
+
+### Requirements
+
+- Nebius CLI installed and configured
+- A Nebius container registry and a push token
+- A Nebius TokenFactory API key
+- Docker (to build the image)
+- Python 3.12 (for the local bridge)
+
+### Runtime / compute
+
+- platform: `cpu-d3`
+- preset: `2vcpu-8gb`
+- estimated cost: $0.14 per hour
+
+## Run
+
+### 1. Set variables
+
+```bash
+export NEBIUS_API_KEY="your-tokenfactory-key"
+export REGISTRY="cr.eu-north1.nebius.cloud/your-registry"
+export SUBNET_ID=$(nebius vpc subnet list --format jsonpath='{.items[0].metadata.id}')
+```
+
+### 2. Build and push the image
+
+```bash
+docker build -t $REGISTRY/mcp-server:latest .
+docker push $REGISTRY/mcp-server:latest
+```
+
+### 3. Create the endpoint
+
+```bash
+nebius ai endpoint create \
+  --name mcp-server \
+  --image $REGISTRY/mcp-server:latest \
+  --platform cpu-d3 \
+  --preset 2vcpu-8gb \
+  --public \
+  --container-port 8000 \
+  --subnet-id "$SUBNET_ID" \
+  --env "NEBIUS_API_KEY=$NEBIUS_API_KEY"
+```
+
+### 4. Get the endpoint URL
+
+```bash
+export MCP_URL=$(nebius ai endpoint get-by-name --name mcp-server \
+  --format json | jq -r '.status.public_endpoints[0]')
+echo $MCP_URL
+```
+
+### 5. Run the local bridge
+
+```bash
+pip install httpx
+python src/bridge.py "http://$MCP_URL"
+```
+
+The bridge reads JSON-RPC from stdin and forwards calls to the remote endpoint.
+
+## Expected output
+
+Health check:
+
+```bash
+curl http://$MCP_URL/health
+```
+
+```json
+{"status":"ok"}
+```
+
+Tool list:
+
+```bash
+curl http://$MCP_URL/tools
+```
+
+```json
+{"tools":[{"name":"embed","description":"Return embedding vector for a text input","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]}
+```
+
+Tool call:
+
+```bash
+curl -X POST http://$MCP_URL/call \
+  -H "Content-Type: application/json" \
+  -d '{"name":"embed","arguments":{"text":"hello world"}}'
+```
+
+```json
+{"content":[{"type":"text","text":"[0.012, -0.034, 0.008, ...] ..."}]}
+```
+
+## How to adapt
+
+- Add more tools to `TOOLS` in `src/server.py` and add matching branches in the `/call` handler
+- Point at a different TokenFactory model by changing `MODEL`
+- Add platform auth with `--auth token` when creating the endpoint for production use
+
+## Troubleshooting
+
+- Endpoint stays in STARTING: check logs with `nebius ai logs <endpoint-id>`
+- Tool call returns 401: check that `NEBIUS_API_KEY` is set correctly in the endpoint env
+- Bridge gets no response: confirm `MCP_URL` does not have a trailing slash
+
+## Cleanup
+
+```bash
+nebius ai endpoint delete \
+  $(nebius ai endpoint get-by-name --name mcp-server --format json | jq -r '.metadata.id')
+```

--- a/agents/mcp-server-endpoint/requirements.txt
+++ b/agents/mcp-server-endpoint/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.0
+httpx==0.27.0

--- a/agents/mcp-server-endpoint/src/bridge.py
+++ b/agents/mcp-server-endpoint/src/bridge.py
@@ -1,0 +1,35 @@
+import sys
+import json
+import httpx
+
+url = sys.argv[1].rstrip("/") if len(sys.argv) > 1 else "http://localhost:8000"
+
+def out(obj):
+    print(json.dumps(obj), flush=True)
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method", "")
+
+    if method == "initialize":
+        out({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mcp-endpoint", "version": "1.0"}
+        }})
+    elif method == "notifications/initialized":
+        pass
+    elif method == "tools/list":
+        r = httpx.get(f"{url}/tools")
+        out({"jsonrpc": "2.0", "id": mid, "result": r.json()})
+    elif method == "tools/call":
+        p = msg["params"]
+        r = httpx.post(f"{url}/call", json={
+            "name": p["name"],
+            "arguments": p.get("arguments", {})
+        })
+        out({"jsonrpc": "2.0", "id": mid, "result": r.json()})

--- a/agents/mcp-server-endpoint/src/server.py
+++ b/agents/mcp-server-endpoint/src/server.py
@@ -1,0 +1,46 @@
+import os
+import httpx
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+API_KEY = os.environ["NEBIUS_API_KEY"]
+BASE_URL = "https://api.ai.nebius.cloud/v1"
+MODEL = "Qwen/Qwen3-Embedding-8B"
+
+TOOLS = [{
+    "name": "embed",
+    "description": "Return embedding vector for a text input",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"]
+    }
+}]
+
+class Call(BaseModel):
+    name: str
+    arguments: dict
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.get("/tools")
+def tools():
+    return {"tools": TOOLS}
+
+@app.post("/call")
+async def call(req: Call):
+    if req.name != "embed":
+        return {"error": f"unknown tool {req.name}"}
+    async with httpx.AsyncClient() as c:
+        r = await c.post(
+            f"{BASE_URL}/embeddings",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={"model": MODEL, "input": req.arguments["text"]},
+            timeout=30,
+        )
+    vec = r.json()["data"][0]["embedding"]
+    return {"content": [{"type": "text", "text": str(vec[:8]) + " ..."}]}

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -1,3 +1,18 @@
+---
+title: OpenClaw AI Gateway on Serverless Endpoint
+category: agents
+type: endpoint
+runtime: cpu
+frameworks:
+  - openclaw
+keywords:
+  - ai-gateway
+  - openai-compatible
+  - tokenfactory
+  - cpu-endpoint
+difficulty: intermediate
+---
+
 # Running OpenClaw Gateway on Nebius Serverless
 
 This tutorial shows how to deploy [OpenClaw](https://github.com/openclaw/openclaw) — an open-source AI gateway — as a serverless CPU endpoint on Nebius AI, connected to TokenFactory model inference.


### PR DESCRIPTION
## What this PR does

Adds a new example under `agents/mcp-server-endpoint` and fixes a missing front matter in `agents/openclaw/README.md`.

This example is based on a hands-on article: [I Ran an MCP Server on the Serverless Endpoints](https://mesutoezdil.substack.com/p/i-ran-an-mcp-server-on-the-serverless)

## Changes

- `agents/mcp-server-endpoint/` - new example: FastAPI server that exposes an MCP tool over HTTP, backed by Nebius TokenFactory (Qwen3-Embedding-8B), with a local bridge for MCP clients
- `agents/openclaw/README.md` - add YAML front matter required by CONTRIBUTING.md
- `README.md` - add new example to the catalog table

## Checklist

- [x] Example runs end to end
- [x] Outcome is clear within 5 minutes
- [x] Compute assumptions are explicit (cpu-d3, 2vcpu-8gb)
- [x] README has expected output
- [x] README has YAML front matter
- [x] No secrets or tenant values committed