### PR TITLE
training: personal-subject FLUX.2 LoRA — train, serve, connect to Claude/ChatGPT

### DIFF
--- a/training/flux-subject-lora-avatar/README.md
+++ b/training/flux-subject-lora-avatar/README.md
@@ -1,0 +1,413 @@
+---
+title: Personal-Subject FLUX.2 LoRA Avatar - Train, Serve, Connect to Claude and ChatGPT
+category: training
+type: workflow
+runtime: gpu
+frameworks:
+  - pytorch
+  - diffusers
+  - ai-toolkit
+keywords:
+  - finetuning
+  - lora
+  - flux
+  - image-generation
+  - object-storage
+  - endpoint
+  - mcp
+  - chatgpt-actions
+difficulty: advanced
+---
+
+# Personal-Subject FLUX.2 LoRA Avatar on Nebius Serverless
+
+Fine-tune a FLUX.2-dev LoRA on 30-60 photos of yourself with a Serverless AI
+Job, serve it behind a token-authenticated Serverless AI Endpoint, and let
+Claude (via MCP) or ChatGPT (via a Custom GPT Action) generate photorealistic
+images of you on demand - with the GPU billing nothing while you are not
+using it.
+
+This example distills a real, validated end-to-end run; the operational
+defaults (preemptible scheduling, resume-after-preemption, timeout budgets,
+S3-FUSE staging patterns, identity gating, cold-start expectations) all come
+from that run.
+
+```text
+ your photos                Serverless AI Job                Serverless AI Endpoint
+ ┌───────────┐   upload    ┌─────────────────────┐  adapter  ┌──────────────────────┐
+ │ 30-60     │ ──────────> │ ai-toolkit           │ ────────> │ FLUX.2-dev           │
+ │ solo shots│  + captions │ FLUX.2-dev LoRA      │  (S3)     │ + your LoRA          │
+ └───────────┘  (S3)       │ ~1-1.5 h on 1 GPU    │           │ /generate (bearer)   │
+       │                   └─────────────────────┘           └──────────┬───────────┘
+       │ holdout refs             │ checkpoints                          │ HTTPS
+       v                          v                                      v
+ ┌───────────┐  ArcFace    ┌─────────────────────┐              ┌───────────────────┐
+ │ refs/     │ <────────── │ score_identity.py    │              │ Claude (MCP)      │
+ │ (never    │  gate, not  │ pick the best step,  │              │ ChatGPT (Action)  │
+ │  trained) │  eyeballing │ not the last one     │              └───────────────────┘
+ └───────────┘             └─────────────────────┘
+```
+
+## What this example does
+
+- prepares a training dataset from your own photos (face-checked, resized,
+  captioned with a rare trigger token, with a held-out reference set)
+- fine-tunes `black-forest-labs/FLUX.2-dev` with LoRA in a Serverless AI Job
+  using the public [ostris/ai-toolkit](https://github.com/ostris/ai-toolkit)
+  runtime image - no custom training image to build
+- optionally scores every checkpoint against the held-out references with an
+  ArcFace identity gate instead of eyeballing sample grids
+- serves base model + adapter through a minimal FastAPI app
+  (diffusers `Flux2Pipeline` + PEFT `load_lora_weights`) on a Serverless AI
+  Endpoint with fail-closed bearer-token auth
+- connects the endpoint to Claude via an MCP server (including endpoint
+  start/stop tools) and to ChatGPT via a Custom GPT Action
+
+## Why this is useful
+
+- **The full arc in one place**: dataset -> training -> quality gate ->
+  serving -> LLM integration, using only Serverless Jobs/Endpoints and
+  Object Storage - no clusters.
+- **On-demand economics**: endpoints bill per second; the runbook here keeps
+  the endpoint stopped when idle and lets your LLM start it when needed.
+- **Code outside the image**: training config and entry script live in the
+  bucket, so you iterate on hyperparameters without building any image.
+- **Hard-won operational defaults**: every non-obvious flag in `train.sh`
+  and `serve.sh` exists because the naive alternative failed in practice
+  (see Troubleshooting).
+
+## Files in this folder
+
+```text
+training/flux-subject-lora-avatar/
+├── README.md
+├── prepare_dataset.py      # photos -> captioned pairs + holdout refs
+├── train_config.yaml       # ai-toolkit recipe (validated defaults)
+├── train.sh                # launch the training job
+├── score_identity.py       # optional ArcFace identity gate
+├── serving/
+│   ├── server.py           # FastAPI + Flux2Pipeline + LoRA, bearer auth
+│   ├── Dockerfile          # serving image
+│   └── serve.sh            # create the endpoint
+├── mcp/
+│   └── server.py           # MCP server for Claude & other MCP clients
+└── chatgpt/
+    ├── openapi.yaml        # Custom GPT Action schema
+    └── gpt-instructions.md # Custom GPT system instructions
+```
+
+## Requirements
+
+- Nebius CLI installed and authenticated; `jq`; Docker; AWS CLI (for Object
+  Storage); Python 3.10+ locally
+- quota for one GPU Serverless AI Job, one GPU Serverless AI Endpoint, and
+  Object Storage
+- a Hugging Face account token: **FLUX.2-dev is a gated model with its own
+  license**. Visit the
+  [model page](https://huggingface.co/black-forest-labs/FLUX.2-dev), accept
+  the license, and read its terms - they govern what you may do with the
+  model and its outputs. Export the token as `HF_TOKEN`.
+
+> **Likeness and consent.** Only train on photos of **your own** likeness,
+> or with the explicit, informed consent of the person depicted. A
+> subject-LoRA endpoint can produce convincing photorealistic images of a
+> real person: keep it private (`--public` never set here), keep the bearer
+> token secret, and never use it to depict anyone deceptively.
+
+## Runtime / compute
+
+- training image: `docker.io/ostris/aitoolkit:latest` (public; pin a digest
+  for reproducibility; the ai-toolkit project is MIT-licensed)
+- serving image: built from `serving/Dockerfile`
+  (`pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime` + `diffusers>=0.36`)
+- example platform/preset: `gpu-h200-sxm` / `1gpu-16vcpu-200gb` (any modern
+  single datacenter GPU with >= 80 GB VRAM works for this quantized recipe)
+- observed timings on one high-end GPU: **~3 s/step**, so the 1200-step
+  recipe is **~1-1.5 h** including the ~90 GB model fetch; endpoint cold
+  start **~15-30 min**; warm generation **~12-45 s** per 1024 px image
+
+## 1. Set variables and create the bucket
+
+```bash
+export PARENT_ID=<PROJECT_ID>                # project-...
+export NB_REGION_ID=<REGION>                 # e.g. eu-north1, us-central1
+export BUCKET_NAME=<YOUR_BUCKET>             # globally unique
+export HF_TOKEN=<your-hf-token>              # accepted the FLUX.2-dev license
+export AWS_ACCESS_KEY_ID=<object-storage-access-key>
+export AWS_SECRET_ACCESS_KEY=<object-storage-secret>
+
+nebius storage bucket create --name "$BUCKET_NAME" --parent-id "$PARENT_ID"
+```
+
+If you need Object Storage credentials, see
+[Working with Object Storage using the AWS CLI](https://docs.nebius.com/object-storage/interfaces/aws-cli).
+
+## 2. Prepare the dataset from your photos
+
+What makes good data (this matters more than any hyperparameter):
+
+- **30-60 solo shots** of you, and only you, per photo
+- **varied** everything: locations, lighting, clothing, angles, expressions,
+  distance (close-ups and full-body) - variety is what lets the model
+  separate *you* from *the scene*
+- sharp faces, short side ideally >= 1024 px; avoid heavy filters,
+  sunglasses in most shots, and group photos
+
+```bash
+pip install pillow insightface onnxruntime opencv-python-headless
+
+python3 prepare_dataset.py \
+  --input ~/my-photos \
+  --output ./prepared \
+  --trigger TOK4ME \
+  --class-word person \
+  --holdout 6
+```
+
+The script verifies each photo contains exactly one face, resizes, writes
+captions like `TOK4ME person, photo` (a `.txt` sidecar next to a source
+photo overrides the default - hand-written varied captions train better),
+and reserves 6 photos as **holdout references** that are never trained on.
+The trigger token is a rare string the base model has no prior for; keep the
+default `TOK4ME` or pick your own and change it everywhere at once
+(captions, `train_config.yaml`, sample prompts, serving env).
+
+Upload:
+
+```bash
+aws --endpoint-url "https://storage.$NB_REGION_ID.nebius.cloud" \
+  s3 cp --recursive ./prepared/dataset "s3://$BUCKET_NAME/flux-avatar/dataset/"
+aws --endpoint-url "https://storage.$NB_REGION_ID.nebius.cloud" \
+  s3 cp --recursive ./prepared/refs "s3://$BUCKET_NAME/flux-avatar/refs/"
+```
+
+## 3. Train
+
+```bash
+chmod +x train.sh
+./train.sh
+```
+
+The script renders `train_config.yaml` (rank-32 LoRA, lr 5e-5, EMA,
+qfloat8-quantized transformer, 1200 steps - a validated recipe), uploads the
+config plus an entry script to the bucket, and creates the job with defaults
+that earned their place:
+
+- `--preemptible` + `--restart-policy on-failure`: preemptible jobs schedule
+  in ~90 s even when the on-demand pool is tight; the entry script preseeds
+  earlier checkpoints from the bucket so a preempted run **resumes** instead
+  of starting over
+- `--timeout 16h`: the timeout is wall clock **including** preemption
+  restarts and the model fetch - budget several times the pure training time
+- `--disk-size 400Gi` and `TMPDIR`/`HF_HOME` redirected into `/workspace`:
+  FLUX.2 model reconstruction is disk-hungry and overflows the default tmp
+- the dataset is staged per-file to local disk (`cat` + size verify): the
+  latent cache is written into the dataset folder, and training directly
+  from the S3-FUSE mount is both slow and fragile
+- checkpoints sync to the bucket every 5 minutes, so even a timed-out job
+  leaves its artifacts behind
+
+Monitor (`nebius ai logs <job-id> --follow`); expect ~3 s/step after the
+model fetch. Checkpoints and sample grids land under
+`s3://$BUCKET_NAME/flux-avatar/output/<run>/<run>/`.
+
+To log to Weights & Biases, set `use_wandb: true` in the config and export
+`WANDB_API_KEY` (and optionally `WANDB_ENTITY`) before `./train.sh`.
+
+## 4. Pick the best checkpoint - do not eyeball
+
+The best checkpoint is frequently **not** the final one, and faces that look
+fine in a sample grid routinely fail a face-embedding check. Score each
+checkpoint's sample images against your holdout references:
+
+```bash
+aws --endpoint-url "https://storage.$NB_REGION_ID.nebius.cloud" \
+  s3 cp --recursive "s3://$BUCKET_NAME/flux-avatar/output/<run>/" ./output/
+
+pip install insightface onnxruntime opencv-python-headless numpy
+python3 score_identity.py --refs ./prepared/refs \
+  --candidates "./output/<run>/samples/*_000001200_*.jpg" --out step1200.json
+# repeat for each saved step (1000, 800, ...) and compare mean/min/pass-rate
+```
+
+Because the references were held out of training, similarity against them is
+an honest identity signal. Pick the checkpoint with the best pass-rate/mean,
+then copy it to a stable serving location:
+
+```bash
+aws --endpoint-url "https://storage.$NB_REGION_ID.nebius.cloud" \
+  s3 cp "s3://$BUCKET_NAME/flux-avatar/output/<run>/<run>/<run>_000001200.safetensors" \
+        "s3://$BUCKET_NAME/flux-avatar/serving/lora.safetensors"
+```
+
+## 5. Build and push the serving image
+
+```bash
+cd serving
+docker build -t <YOUR_REGISTRY>/flux-avatar-serving:v1 .
+docker push <YOUR_REGISTRY>/flux-avatar-serving:v1
+```
+
+Push to an **in-region Nebius Container Registry**
+(`cr.<region>.nebius.cloud/<registry-id>/...`) - in-region pulls take
+seconds to a few minutes; cross-region first pulls can add many minutes to
+every cold start.
+
+## 6. Create the endpoint
+
+```bash
+export SERVING_IMAGE=<YOUR_REGISTRY>/flux-avatar-serving:v1
+chmod +x serving/serve.sh
+./serving/serve.sh
+```
+
+This creates a **private** (`--public` never set), token-authenticated
+endpoint with the bucket mounted read-only for the adapter. One bearer token
+(written to `./endpoint.token`, chmod 600) passes both auth layers: the
+platform `--auth token` proxy and the fail-closed in-container check.
+Exporting `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` first enables
+`response_format: "url"` (required for ChatGPT later).
+
+Wait for `state=RUNNING`, then poll `/healthz` until `ready: true`
+(cold start ~15-30 min: image pull + ~90 GB model download + load). The
+script prints the smoke-test commands, including the auth check - an
+unauthenticated `/generate` must return **401**.
+
+The endpoint's HTTPS URL:
+
+```bash
+EP_URL=$(nebius ai endpoint get <endpoint-id> --format json \
+  | jq -r '.status.public_endpoints[0]')
+```
+
+> **The hostname is not stable.** Every stop/start cycle mints a **new**
+> HTTPS hostname; the old one starts returning 404. Always re-resolve the
+> URL after starting the endpoint. (There is currently no custom-domain
+> option for Serverless Endpoints.)
+
+**Cost discipline:** a running GPU endpoint bills per second around the
+clock. Stop it whenever you are done; it keeps its ID, token, and adapter:
+
+```bash
+nebius ai endpoint stop <endpoint-id>     # idle: bills nothing
+nebius ai endpoint start <endpoint-id>    # ~15-30 min back to ready
+```
+
+## 7. Connect Claude via MCP
+
+`mcp/server.py` wraps the endpoint as MCP tools - `avatar_endpoint_status`,
+`avatar_endpoint_start`, `avatar_endpoint_stop`, and
+`generate_avatar_image` - so Claude can manage the on-demand lifecycle
+itself: check status, start the endpoint, poll until ready, generate, and
+stop it when you are done. It resolves the endpoint URL at **call time** via
+the CLI, so restarts (and their new hostnames) just work.
+
+```bash
+python3 -m venv mcp/venv && mcp/venv/bin/pip install mcp
+```
+
+Claude Code:
+
+```bash
+claude mcp add flux-avatar \
+  -e ENDPOINT_ID=<endpoint-id> \
+  -e AUTH_TOKEN_FILE=/absolute/path/to/endpoint.token \
+  -- /absolute/path/to/mcp/venv/bin/python /absolute/path/to/mcp/server.py
+```
+
+Claude Desktop (`claude_desktop_config.json`) and other MCP clients use the
+same shape:
+
+```json
+{
+  "mcpServers": {
+    "flux-avatar": {
+      "command": "/absolute/path/to/mcp/venv/bin/python",
+      "args": ["/absolute/path/to/mcp/server.py"],
+      "env": {
+        "ENDPOINT_ID": "<endpoint-id>",
+        "AUTH_TOKEN_FILE": "/absolute/path/to/endpoint.token",
+        "TRIGGER_WORD": "TOK4ME",
+        "TRIGGER_CLASS": "person"
+      }
+    }
+  }
+}
+```
+
+The machine running the MCP server needs the authenticated `nebius` CLI (for
+start/stop/status and URL resolution) and read access to the token file.
+Then simply ask Claude: *"generate a picture of me hiking at sunrise -
+start the endpoint if it's stopped, and stop it when we're done."*
+
+## 8. Connect ChatGPT via a Custom GPT Action
+
+1. ChatGPT -> Explore GPTs -> **Create a GPT** -> Configure.
+2. Paste `chatgpt/gpt-instructions.md` (below the divider) into
+   **Instructions**.
+3. **Actions -> Create new action**: paste `chatgpt/openapi.yaml` into the
+   schema field, replacing the server URL with your endpoint's current one
+   (`jq -r '.status.public_endpoints[0]'` as above).
+4. Authentication: **API Key**, Auth Type **Bearer**, paste the token from
+   `endpoint.token`.
+5. Privacy: keep the GPT **"Only me"**. Anyone with access to the GPT
+   effectively holds your endpoint token - and your likeness.
+
+Why `response_format: "url"`: ChatGPT truncates Action responses at roughly
+**100 KB**. A 1024 px PNG is a couple of megabytes, so an inline base64
+response can never arrive. In `url` mode the endpoint uploads the PNG to
+Object Storage and returns a presigned URL (expires ~1 h) that the GPT
+renders inline with markdown.
+
+Two operational caveats ChatGPT cannot work around itself:
+
+- it cannot start/stop your endpoint - do that from your machine (or ask
+  Claude via MCP) before and after a session
+- after every endpoint restart the Action's server URL is stale (the old
+  hostname 404s) - re-paste the new URL into the GPT's schema
+
+## Expected output
+
+- the training job reaches `COMPLETED` with LoRA checkpoints + sample grids
+  in the bucket
+- `score_identity.py` shows a clear winner checkpoint (pass-rate >= 0.8
+  against holdout refs is a strong solo adapter)
+- the endpoint reaches `RUNNING`, `/healthz` reports `ready: true`,
+  unauthenticated requests get **401**, authenticated `/generate` returns an
+  image in ~12-45 s
+- Claude and ChatGPT render images of you from plain-language requests
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| Job stuck / fails with `NotEnoughResources` | The on-demand GPU pool is tight. For **jobs**: use `--preemptible` (schedules in ~90 s, default here). For **endpoints** (which cannot be preemptible): start the endpoint **before** launching batch jobs that compete for the same pool, or free a slot first; a starved endpoint create times out after ~25 min in `ERROR` - delete and recreate it. |
+| Job dies with `TimeoutExceeded` mid-training | `--timeout` counts wall clock **including** preemption restarts and the ~90 GB model fetch. Budget generously (>= 12 h for a ~1.5 h train); the periodic checkpoint sync means a relaunch resumes from the last saved step. |
+| Job crash-loops with `Stale file handle` / `cp` errors on the S3 mount | Never run long-lived scripts directly from the S3-FUSE mount and never train against it: copy scripts and dataset to local disk first (the entry script in `train.sh` does both), and write outputs locally with periodic sync back. |
+| ChatGPT Action "fails" although the endpoint works | Action responses are truncated at ~100 KB - use `response_format: "url"`, never base64, for ChatGPT. If the Action gets 404s, the endpoint was restarted and the schema's server URL points at the old hostname. |
+| `/healthz` returns 404 | Stale hostname (endpoint was restarted - re-resolve the URL) or the container is not listening yet (cold start). Only `ready: true` on the **current** URL means the endpoint is up. |
+| `nebius ai job create` / `endpoint start` seems to hang | `create` blocks until the workload is scheduled and `start` several minutes - this is normal; poll `... get <id>` from another shell. |
+| "multiple subnets found" on create | Projects with several subnets require an explicit `--subnet-id`; the scripts pick the first subnet - override `SUBNET_ID` if needed. |
+| Disk-full during model load | FLUX.2 reconstruction needs a lot of scratch space: keep `--disk-size` >= 400Gi for training / 300Gi for serving and the `TMPDIR`/`HF_HOME` redirects. |
+| Weak likeness despite low loss | Data problem first: more variety, sharper faces, exactly one person per shot. Then let `score_identity.py` pick the step - the last checkpoint is often overcooked. Never describe the face in prompts; the trigger token carries identity. |
+
+## Security notes
+
+- The endpoint is never `--public`; its HTTPS URL is token-gated by the
+  platform proxy, and the container refuses requests without the bearer
+  token (fail-closed) as a second layer.
+- `--env` values are visible to project members via `nebius ai job/endpoint
+  get`. In shared projects move `HF_TOKEN`, `API_TOKEN`, and cloud
+  credentials into MysteryBox secrets (`--env-secret`, `--token-secret`).
+- Presigned image URLs are unguessable but fetchable by anyone holding the
+  link until expiry - do not post them publicly.
+- Treat the bearer token like a password to your own face; rotate it
+  (recreate the endpoint) if it may have leaked.
+
+## Cleanup
+
+```bash
+nebius ai job delete <job-id>            # after collecting artifacts
+nebius ai endpoint delete <endpoint-id>  # when you no longer need serving
+# remove bucket contents + bucket if you are done with the project
+```

--- a/training/flux-subject-lora-avatar/chatgpt/gpt-instructions.md
+++ b/training/flux-subject-lora-avatar/chatgpt/gpt-instructions.md
@@ -1,0 +1,47 @@
+# Custom GPT system instructions
+
+Paste the text below into the Custom GPT "Instructions" field. Replace
+`TOK4ME person` with your trigger token and class word if you changed them.
+
+---
+
+You are the owner's private image generator. You call a personal FLUX.2 LoRA
+endpoint (via the generateAvatarImage action) that renders photorealistic
+pictures of the owner - and only the owner. Rules:
+
+1. PROMPT CONSTRUCTION: Build the `prompt` as: "TOK4ME person, " followed by
+   the scene/style the user asked for (clothing, setting, lighting, mood,
+   photo style). NEVER describe the subject's face, hair, or age - the
+   trained trigger token carries the identity, and describing the face
+   degrades likeness. Good example: "TOK4ME person, seated at a cafe,
+   natural candid photo, soft window light". Photorealistic, single-person
+   compositions work best; warn the user that stylized/cartoon looks and
+   multi-person scenes are less reliable.
+
+2. CALL SEQUENCE: On the first generation of a conversation, call
+   checkHealth first. If it fails or `ready` is not true, tell the user the
+   endpoint is offline and that they must start it from their own machine
+   (`nebius ai endpoint start <endpoint-id>`, ready in ~15-30 minutes) - do
+   not retry in a loop. If the call errors with a "not found" page, the
+   endpoint was probably restarted and got a NEW hostname: the user must
+   update this GPT's Action schema server URL.
+
+3. GENERATION: Call generateAvatarImage with the constructed prompt and
+   `response_format: "url"` (inline base64 exceeds the Action response
+   limit). Defaults: width 1024, height 1024, steps 28, guidance_scale 4.0.
+   Sizes must be multiples of 64 (256-1536). Pass a `seed` only when the
+   user wants reproducibility or a variation of a previous image.
+
+4. DISPLAY: Render the result inline with markdown:
+   `![generated image](image_url)`. Mention the seed so the user can
+   iterate. The URL expires after about an hour - tell the user to save
+   images they want to keep.
+
+5. COST DISCIPLINE: The endpoint bills a GPU while running. If the user says
+   they are done, remind them to stop it from their machine (you cannot
+   stop it yourself).
+
+6. SCOPE: This endpoint exists solely for the owner to generate images of
+   their own likeness. Refuse requests to depict other real people, and
+   refuse demeaning, deceptive, explicit, or otherwise misusable
+   depictions - offer a tasteful alternative instead.

--- a/training/flux-subject-lora-avatar/chatgpt/openapi.yaml
+++ b/training/flux-subject-lora-avatar/chatgpt/openapi.yaml
@@ -1,0 +1,97 @@
+# OpenAPI schema for a ChatGPT Custom GPT Action calling your endpoint.
+# Paste into: Create a GPT -> Configure -> Actions -> schema field.
+#
+# IMPORTANT: replace the server URL with your endpoint's CURRENT HTTPS URL:
+#   nebius ai endpoint get <endpoint-id> --format json \
+#     | jq -r '.status.public_endpoints[0]'
+# The hostname changes EVERY TIME the endpoint is stopped and started again;
+# re-paste it here (and save the GPT) after each restart.
+openapi: 3.1.0
+info:
+  title: Personal Avatar Image Endpoint
+  description: >-
+    Private FLUX.2 LoRA endpoint that generates photorealistic images of the
+    GPT owner's trained likeness.
+  version: "1.0"
+servers:
+  - url: https://<YOUR-ENDPOINT-HOSTNAME>
+paths:
+  /healthz:
+    get:
+      operationId: checkHealth
+      summary: Check whether the image endpoint is up and the model is loaded.
+      responses:
+        "200":
+          description: Health state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ready:
+                    type: boolean
+                  model:
+                    type: string
+  /generate:
+    post:
+      operationId: generateAvatarImage
+      summary: Generate a photorealistic image and return a temporary image URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [prompt]
+              properties:
+                prompt:
+                  type: string
+                  description: >-
+                    Must start with "TOK4ME person, " (the trained trigger
+                    token) followed by scene/style only - never describe the
+                    face.
+                width:
+                  type: integer
+                  default: 1024
+                  description: Multiple of 64, 256-1536.
+                height:
+                  type: integer
+                  default: 1024
+                  description: Multiple of 64, 256-1536.
+                steps:
+                  type: integer
+                  default: 28
+                guidance_scale:
+                  type: number
+                  default: 4.0
+                seed:
+                  type: integer
+                  description: Optional. Same seed + prompt reproduces the image.
+                response_format:
+                  type: string
+                  enum: [url]
+                  default: url
+                  description: >-
+                    Always "url". ChatGPT truncates Action responses at about
+                    100 KB, so an inline base64 PNG (megabytes) can never
+                    arrive; the endpoint instead uploads the PNG to Object
+                    Storage and returns a short-lived presigned URL.
+      responses:
+        "200":
+          description: Generated image
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  image_url:
+                    type: string
+                    description: Presigned HTTPS URL of the PNG (expires ~1 hour).
+                  seed:
+                    type: integer
+                  expires_in_seconds:
+                    type: integer
+        "401":
+          description: Missing or invalid Bearer token.
+        "503":
+          description: Model still loading (or auth not configured).

--- a/training/flux-subject-lora-avatar/mcp/server.py
+++ b/training/flux-subject-lora-avatar/mcp/server.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""MCP server exposing your personal FLUX.2 LoRA endpoint to Claude (or any
+MCP client): generate images of yourself, plus start/stop/status tools so the
+model can manage the on-demand GPU endpoint for you.
+
+Environment (set in your MCP client config):
+  ENDPOINT_ID      Nebius endpoint id (aiendpoint-...). Enables start/stop/
+                   status via the nebius CLI AND call-time URL resolution.
+  AUTH_TOKEN_FILE  path to the bearer-token file written by serve.sh
+                   (or AUTH_TOKEN with the literal token - file preferred)
+  ENDPOINT_URL     optional static override of the endpoint URL. NOTE: the
+                   HTTPS hostname changes on every endpoint stop/start, so
+                   prefer ENDPOINT_ID and let this server resolve the current
+                   URL at call time.
+  NEBIUS_PROFILE   optional nebius CLI profile name
+  TRIGGER_WORD     your trigger token (default TOK4ME)
+  TRIGGER_CLASS    class noun (default person)
+  OUTPUT_DIR       where generated PNGs are saved (default ~/flux-avatar-images)
+
+Run: pip install mcp; then register with your client (see the README).
+Secrets are read at call time and never logged or returned to the model.
+"""
+import base64
+import json
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP, Image
+
+ENDPOINT_ID = os.environ.get("ENDPOINT_ID", "")
+ENDPOINT_URL = os.environ.get("ENDPOINT_URL", "")
+TRIGGER_WORD = os.environ.get("TRIGGER_WORD", "TOK4ME")
+TRIGGER_CLASS = os.environ.get("TRIGGER_CLASS", "person")
+OUTPUT_DIR = os.environ.get(
+    "OUTPUT_DIR", os.path.expanduser("~/flux-avatar-images"))
+
+
+def _nebius_cmd() -> list:
+    cmd = ["nebius"]
+    profile = os.environ.get("NEBIUS_PROFILE", "")
+    if profile:
+        cmd += ["--profile", profile]
+    return cmd + ["ai", "endpoint"]
+
+
+mcp = FastMCP(
+    "flux-avatar",
+    instructions=(
+        "Generate photorealistic images of the owner's trained likeness via "
+        "a private FLUX.2 LoRA endpoint. The endpoint is stopped when idle "
+        "to save GPU cost: call avatar_endpoint_status first; if it is not "
+        "running, call avatar_endpoint_start and poll status until ready "
+        "(~15-30 min), then call generate_avatar_image. Stop the endpoint "
+        "again when the user is done generating."
+    ),
+)
+
+
+def _auth_token() -> str:
+    token = os.environ.get("AUTH_TOKEN", "")
+    token_file = os.environ.get("AUTH_TOKEN_FILE", "")
+    if not token and token_file and os.path.exists(token_file):
+        with open(token_file, encoding="utf-8") as fh:
+            token = fh.read().strip()
+    if not token:
+        raise RuntimeError("set AUTH_TOKEN_FILE (or AUTH_TOKEN) in the MCP "
+                           "server environment")
+    return token
+
+
+def _endpoint_url() -> str:
+    """Resolve the CURRENT endpoint URL. The tunnel hostname changes on every
+    stop/start cycle, so when ENDPOINT_ID is set we always ask the CLI."""
+    if ENDPOINT_ID:
+        out = subprocess.run(
+            _nebius_cmd() + ["get", ENDPOINT_ID, "--format",
+                             "jsonpath={.status.public_endpoints[0]}"],
+            capture_output=True, text=True, timeout=60,
+        )
+        url = out.stdout.strip().strip('"')
+        if url.startswith("http"):
+            return url.rstrip("/")
+    if ENDPOINT_URL:
+        return ENDPOINT_URL.rstrip("/")
+    raise RuntimeError("set ENDPOINT_ID (preferred) or ENDPOINT_URL in the "
+                       "MCP server environment")
+
+
+def _http(path: str, body=None, timeout=600):
+    req = urllib.request.Request(
+        _endpoint_url() + path,
+        data=json.dumps(body).encode() if body is not None else None,
+        method="POST" if body is not None else "GET",
+    )
+    req.add_header("Authorization", "Bearer " + _auth_token())
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode())
+        except Exception:
+            payload = {}
+        return exc.code, payload
+
+
+def _cli_state() -> str:
+    if not ENDPOINT_ID:
+        return "UNKNOWN (ENDPOINT_ID not set)"
+    out = subprocess.run(
+        _nebius_cmd() + ["get", ENDPOINT_ID, "--format",
+                         "jsonpath={.status.state}"],
+        capture_output=True, text=True, timeout=60,
+    )
+    return (out.stdout or out.stderr).strip().strip('"') or "UNKNOWN"
+
+
+@mcp.tool()
+def avatar_endpoint_status() -> str:
+    """Check whether the avatar image endpoint is running and ready.
+
+    Returns the platform state (RUNNING/STOPPED/STARTING/...) and, when
+    running, whether the model finished loading. Generation only works when
+    state=RUNNING and ready=true.
+    """
+    state = _cli_state()
+    if "RUNNING" not in state:
+        return (f"state={state}. Not ready. Use avatar_endpoint_start "
+                f"(cold start ~15-30 min), then poll this tool.")
+    code, health = _http("/healthz", timeout=30)
+    ready = health.get("ready") if isinstance(health, dict) else None
+    return (f"state=RUNNING, healthz http={code}, ready={ready}. "
+            + ("Ready to generate." if ready else
+               "Still loading the model - poll again in a few minutes."))
+
+
+@mcp.tool()
+def avatar_endpoint_start() -> str:
+    """Start the stopped avatar endpoint. Billing note: it occupies a
+    dedicated GPU until stopped. The start command itself takes a few
+    minutes; full cold start to ready is ~15-30 minutes (model download +
+    load). Poll avatar_endpoint_status until ready=true."""
+    if not ENDPOINT_ID:
+        return "ENDPOINT_ID is not set; cannot manage the endpoint."
+    state = _cli_state()
+    if state == "RUNNING":
+        return "Already RUNNING."
+    out = subprocess.run(_nebius_cmd() + ["start", ENDPOINT_ID],
+                         capture_output=True, text=True, timeout=600)
+    if out.returncode != 0:
+        return f"start failed: {out.stderr.strip()[:400]}"
+    return ("Start issued. Expect ~15-30 min until ready=true (poll "
+            "avatar_endpoint_status). Remember avatar_endpoint_stop when "
+            "done to stop GPU billing.")
+
+
+@mcp.tool()
+def avatar_endpoint_stop() -> str:
+    """Stop the avatar endpoint to stop GPU billing. It keeps its identity
+    and adapter and can be restarted later. Call when the user is done."""
+    if not ENDPOINT_ID:
+        return "ENDPOINT_ID is not set; cannot manage the endpoint."
+    out = subprocess.run(_nebius_cmd() + ["stop", ENDPOINT_ID],
+                         capture_output=True, text=True, timeout=600)
+    if out.returncode != 0:
+        return f"stop failed: {out.stderr.strip()[:400]}"
+    return ("Stop issued. Note: the endpoint's HTTPS hostname will be "
+            "DIFFERENT after the next start; this server re-resolves it "
+            "automatically.")
+
+
+@mcp.tool()
+def generate_avatar_image(
+    scene: str,
+    width: int = 1024,
+    height: int = 1024,
+    steps: int = 28,
+    guidance_scale: float = 4.0,
+    seed: Optional[int] = None,
+) -> list:
+    """Generate a photorealistic image of the trained subject.
+
+    Describe only the scene/style/clothing/lighting in `scene` (e.g. "seated
+    at a cafe, natural candid photo"); the subject's identity is injected via
+    the trained trigger token - do NOT describe their face. Photorealistic,
+    single-person compositions are most reliable. Takes ~15-45 s when the
+    endpoint is warm; fails fast when it is stopped (use
+    avatar_endpoint_start first). Sizes must be multiples of 64 (256-1536).
+    Same seed + prompt = same image. Returns the image plus the saved path.
+    """
+    state = _cli_state()
+    if ENDPOINT_ID and "RUNNING" not in state:
+        return [f"Endpoint is {state}, not RUNNING. Call "
+                f"avatar_endpoint_start (~15-30 min), poll "
+                f"avatar_endpoint_status, then retry."]
+    if TRIGGER_WORD.lower() in scene.lower():
+        prompt = scene
+    else:
+        prompt = f"{TRIGGER_WORD} {TRIGGER_CLASS}, {scene}"
+    if seed is None:
+        seed = int.from_bytes(os.urandom(4), "big") % 2**31
+    body = {"prompt": prompt, "width": width, "height": height,
+            "steps": steps, "guidance_scale": guidance_scale, "seed": seed,
+            "response_format": "base64"}
+    started = time.time()
+    code, resp = _http("/generate", body)
+    elapsed = time.time() - started
+    if code != 200 or not resp.get("image_base64"):
+        err = {k: v for k, v in resp.items() if k != "image_base64"}
+        return [f"generation failed: http={code} after {elapsed:.0f}s: "
+                f"{json.dumps(err)[:400]}"]
+    png = base64.b64decode(resp["image_base64"])
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    fname = f"avatar_{time.strftime('%Y%m%d-%H%M%S')}_seed{seed}.png"
+    fpath = os.path.join(OUTPUT_DIR, fname)
+    with open(fpath, "wb") as fh:
+        fh.write(png)
+    return [
+        Image(data=png, format="png"),
+        f"Saved to {fpath} (seed={seed}, {elapsed:.0f}s, prompt: {prompt!r})",
+    ]
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/training/flux-subject-lora-avatar/prepare_dataset.py
+++ b/training/flux-subject-lora-avatar/prepare_dataset.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare a personal-photo dataset for FLUX.2 subject-LoRA fine-tuning.
+
+Takes a folder of your own photos and produces the layout the training job
+expects:
+
+    <output>/dataset/   img_001.jpg + img_001.txt  (training pairs)
+    <output>/refs/      held-out reference photos  (identity scoring, never trained)
+
+What it does per image:
+  - applies EXIF rotation, converts to RGB, re-encodes as JPEG
+  - optionally verifies the photo contains EXACTLY ONE detectable face
+    (insightface; use --no-face-check to skip if you curated by hand)
+  - downsizes so the longest side is <= --max-side, warns if the short
+    side is below --min-side (low-res faces hurt identity)
+  - writes a caption file that starts with the trigger token, e.g.
+    "TOK4ME person, photo". If a .txt sidecar with the same stem exists
+    next to the input image, its text is used instead (the trigger prefix
+    is added if missing). Hand-written, varied captions train better.
+  - reserves --holdout images (seeded random pick) as identity references;
+    they are NOT trained on, so scoring against them is honest.
+
+Output stems are neutral (img_###) on purpose: never rely on filename-based
+trigger inference in any trainer - the trigger token is set explicitly in the
+training config.
+
+Example:
+    python3 prepare_dataset.py --input ~/my-photos --output ./prepared \\
+        --trigger TOK4ME --class-word person --holdout 6
+"""
+import argparse
+import random
+import shutil
+import sys
+from pathlib import Path
+
+IMG_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--input", required=True, help="folder with your source photos")
+    p.add_argument("--output", required=True, help="output folder (created)")
+    p.add_argument("--trigger", default="TOK4ME",
+                   help="trigger token; a rare string the model has never seen "
+                        "(default: TOK4ME). Keep the case consistent everywhere.")
+    p.add_argument("--class-word", default="person",
+                   help="class noun after the trigger, e.g. man / woman / person")
+    p.add_argument("--caption-suffix", default="photo",
+                   help="default caption tail when no .txt sidecar exists")
+    p.add_argument("--holdout", type=int, default=6,
+                   help="number of images reserved as identity references (default 6)")
+    p.add_argument("--max-side", type=int, default=1536,
+                   help="downsize so the longest side is at most this (default 1536)")
+    p.add_argument("--min-side", type=int, default=768,
+                   help="warn when the short side is below this (default 768)")
+    p.add_argument("--jpeg-quality", type=int, default=95)
+    p.add_argument("--seed", type=int, default=42, help="holdout selection seed")
+    p.add_argument("--no-face-check", action="store_true",
+                   help="skip the insightface single-face verification")
+    return p.parse_args()
+
+
+def load_face_detector():
+    try:
+        from insightface.app import FaceAnalysis
+    except ImportError:
+        sys.exit(
+            "insightface is not installed. Either:\n"
+            "  pip install insightface onnxruntime opencv-python-headless\n"
+            "or rerun with --no-face-check if you curated the photos by hand."
+        )
+    det = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+    det.prepare(ctx_id=-1, det_size=(640, 640))
+    return det
+
+
+def count_faces(detector, image):
+    import numpy as np
+    bgr = np.asarray(image)[:, :, ::-1]  # PIL RGB -> OpenCV BGR
+    faces = [f for f in detector.get(bgr) if getattr(f, "det_score", 1.0) >= 0.5]
+    return len(faces)
+
+
+def build_caption(src: Path, trigger: str, class_word: str, suffix: str) -> str:
+    sidecar = src.with_suffix(".txt")
+    if sidecar.exists():
+        text = sidecar.read_text(encoding="utf-8").strip()
+        if trigger not in text:
+            text = f"{trigger} {class_word}, {text}"
+        return text
+    return f"{trigger} {class_word}, {suffix}"
+
+
+def main():
+    args = parse_args()
+    try:
+        from PIL import Image, ImageOps
+    except ImportError:
+        sys.exit("Pillow is required: pip install pillow")
+
+    src_dir = Path(args.input)
+    out_dir = Path(args.output)
+    dataset_dir = out_dir / "dataset"
+    refs_dir = out_dir / "refs"
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    sources = sorted(
+        p for p in src_dir.iterdir()
+        if p.is_file() and p.suffix.lower() in IMG_EXTS
+    )
+    if not sources:
+        sys.exit(f"no images found in {src_dir}")
+
+    detector = None if args.no_face_check else load_face_detector()
+
+    rng = random.Random(args.seed)
+    holdout_set = set(rng.sample(range(len(sources)), min(args.holdout, len(sources))))
+
+    kept, skipped, low_res, ref_count = 0, 0, 0, 0
+    for idx, src in enumerate(sources):
+        with Image.open(src) as im:
+            img = ImageOps.exif_transpose(im).convert("RGB")
+
+        if detector is not None:
+            n = count_faces(detector, img)
+            if n != 1:
+                print(f"SKIP {src.name}: {n} faces detected (need exactly 1)")
+                skipped += 1
+                continue
+
+        w, h = img.size
+        if max(w, h) > args.max_side:
+            scale = args.max_side / max(w, h)
+            img = img.resize((round(w * scale), round(h * scale)), Image.LANCZOS)
+        if min(img.size) < args.min_side:
+            print(f"WARN {src.name}: short side {min(img.size)}px < {args.min_side}px")
+            low_res += 1
+
+        if idx in holdout_set:
+            ref_count += 1
+            img.save(refs_dir / f"ref_{ref_count:03d}.jpg",
+                     quality=args.jpeg_quality)
+            continue
+
+        kept += 1
+        stem = f"img_{kept:03d}"
+        img.save(dataset_dir / f"{stem}.jpg", quality=args.jpeg_quality)
+        caption = build_caption(src, args.trigger, args.class_word,
+                                args.caption_suffix)
+        (dataset_dir / f"{stem}.txt").write_text(caption + "\n", encoding="utf-8")
+
+    print(f"\ntraining pairs: {kept}  holdout refs: {ref_count}  "
+          f"skipped: {skipped}  low-res warnings: {low_res}")
+    if kept < 30:
+        print("NOTE: 30-60 varied solo shots is the sweet spot; "
+              "fewer images usually means weaker identity.")
+    print(f"""
+Next step - upload to Object Storage (adjust bucket/region):
+
+  aws --endpoint-url "https://storage.<REGION>.nebius.cloud" \\
+    s3 cp --recursive {dataset_dir} s3://<YOUR_BUCKET>/flux-avatar/dataset/
+  aws --endpoint-url "https://storage.<REGION>.nebius.cloud" \\
+    s3 cp --recursive {refs_dir} s3://<YOUR_BUCKET>/flux-avatar/refs/
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/flux-subject-lora-avatar/score_identity.py
+++ b/training/flux-subject-lora-avatar/score_identity.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Identity gate: score generated images against held-out reference photos.
+
+Do not eyeball checkpoint sample grids - faces that "look right" at grid size
+routinely fail a face-embedding check, and the best checkpoint is often not
+the last one. This script embeds faces with ArcFace (insightface buffalo_l,
+CPU is fine) and reports the cosine similarity of each candidate image's
+largest face against your held-out reference set (the photos that
+prepare_dataset.py reserved and that were NEVER trained on).
+
+Per candidate the similarity is max(best-vs-any-ref, mean-vs-mean-embedding).
+
+Usage:
+  python3 score_identity.py --refs prepared/refs \
+      --candidates "output/<run>/<run>/samples/*.jpg" --out scores.json
+
+Point --candidates at each checkpoint's sample images (or at images you
+generated from the endpoint) and compare mean/min/pass-rate across
+checkpoints; serve the winner.
+
+The default threshold 0.42 is a starting point from a calibrated run
+(genuine-vs-impostor midpoint). Calibrate for your own face if you can:
+score a few genuine photos (should land well above) and a few photos of
+other people (should land well below), then pick the midpoint.
+
+Requires: pip install insightface onnxruntime opencv-python-headless numpy
+(first run downloads the buffalo_l model pack, ~300 MB).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+IMG_EXTS = (".jpg", ".jpeg", ".png", ".webp", ".bmp")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--refs", required=True,
+                   help="folder of held-out reference photos (one face each)")
+    p.add_argument("--candidates", required=True,
+                   help="folder or glob of generated images to score")
+    p.add_argument("--threshold", type=float, default=0.42,
+                   help="pass threshold on cosine similarity (default 0.42)")
+    p.add_argument("--out", default="",
+                   help="optional path to write full JSON results")
+    return p.parse_args()
+
+
+def collect(spec):
+    if os.path.isdir(spec):
+        return [os.path.join(spec, f) for f in sorted(os.listdir(spec))
+                if f.lower().endswith(IMG_EXTS)]
+    return sorted(p for p in glob.glob(spec) if p.lower().endswith(IMG_EXTS))
+
+
+def main():
+    args = parse_args()
+    try:
+        import cv2
+        import numpy as np
+        from insightface.app import FaceAnalysis
+    except ImportError:
+        sys.exit("missing deps: pip install insightface onnxruntime "
+                 "opencv-python-headless numpy")
+
+    det = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+    det.prepare(ctx_id=-1, det_size=(640, 640))
+
+    def largest_face_embedding(path):
+        img = cv2.imread(path)
+        if img is None:
+            return None
+        faces = det.get(img)
+        if not faces:
+            return None
+        face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) *
+                                        (f.bbox[3] - f.bbox[1]))
+        emb = face.normed_embedding.astype(np.float32)
+        return emb / np.linalg.norm(emb)
+
+    # ---- reference embeddings ----
+    ref_paths = collect(args.refs)
+    if not ref_paths:
+        sys.exit(f"no reference images in {args.refs}")
+    refs = []
+    for p in ref_paths:
+        emb = largest_face_embedding(p)
+        if emb is None:
+            print(f"WARN ref {os.path.basename(p)}: no face detected, skipped")
+            continue
+        refs.append(emb)
+    if not refs:
+        sys.exit("no usable reference faces")
+    refs = np.stack(refs)
+    ref_mean = refs.mean(axis=0)
+    ref_mean /= np.linalg.norm(ref_mean)
+    print(f"references: {len(refs)} usable faces from {len(ref_paths)} images")
+
+    # ---- candidates ----
+    cand_paths = collect(args.candidates)
+    if not cand_paths:
+        sys.exit(f"no candidate images match {args.candidates}")
+
+    results, sims = [], []
+    for p in cand_paths:
+        emb = largest_face_embedding(p)
+        if emb is None:
+            results.append({"image": p, "similarity": None, "passed": False,
+                            "note": "no face detected"})
+            print(f"{os.path.basename(p):50s}  NO FACE            FAIL")
+            continue
+        sim = float(max(float((refs @ emb).max()), float(ref_mean @ emb)))
+        passed = sim >= args.threshold
+        sims.append(sim)
+        results.append({"image": p, "similarity": round(sim, 4),
+                        "passed": passed})
+        print(f"{os.path.basename(p):50s}  sim={sim:6.4f}  "
+              f"{'PASS' if passed else 'FAIL'}")
+
+    n = len(results)
+    n_pass = sum(1 for r in results if r["passed"])
+    summary = {
+        "candidates": n,
+        "passed": n_pass,
+        "pass_rate": round(n_pass / n, 4) if n else 0.0,
+        "mean_similarity": round(sum(sims) / len(sims), 4) if sims else None,
+        "min_similarity": round(min(sims), 4) if sims else None,
+        "threshold": args.threshold,
+    }
+    print("\nsummary:", json.dumps(summary))
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump({"summary": summary, "results": results}, fh, indent=2)
+        print(f"full results -> {args.out}")
+    # nonzero exit if fewer than half pass, so CI-style gating works
+    sys.exit(0 if n and n_pass / n >= 0.5 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/flux-subject-lora-avatar/serving/Dockerfile
+++ b/training/flux-subject-lora-avatar/serving/Dockerfile
@@ -1,0 +1,34 @@
+# FLUX.2-dev + LoRA serving image (solo subject mode).
+# Flux2Pipeline is available in diffusers >= 0.36.0.
+FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    HF_HOME=/cache/hf \
+    HOME=/tmp
+
+RUN python -m pip install --upgrade pip && \
+    python -m pip install --no-cache-dir \
+      diffusers==0.39.0 \
+      transformers==4.57.6 \
+      accelerate==1.14.0 \
+      peft==0.19.1 \
+      sentencepiece \
+      protobuf \
+      safetensors \
+      fastapi==0.139.2 \
+      "uvicorn[standard]==0.51.0" \
+      pillow \
+      boto3 \
+      huggingface_hub \
+      hf_transfer && \
+    python -c "from diffusers import Flux2Pipeline; import peft, boto3; print('import check ok')"
+
+COPY server.py /app/server.py
+WORKDIR /app
+RUN mkdir -p /cache && chmod -R 777 /cache
+
+EXPOSE 8000
+CMD ["python", "-m", "uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/training/flux-subject-lora-avatar/serving/serve.sh
+++ b/training/flux-subject-lora-avatar/serving/serve.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Create a token-authenticated Nebius Serverless AI Endpoint serving
+# FLUX.2-dev + your subject LoRA.
+#
+# Prereqs:
+#   - the serving image is built from serving/Dockerfile and pushed to a
+#     registry the endpoint can pull from (an in-region Nebius Container
+#     Registry gives much faster cold starts than a cross-region pull)
+#   - the winning adapter is uploaded to
+#     s3://$BUCKET_NAME/$PREFIX/serving/lora.safetensors
+#
+# Required env: PARENT_ID, BUCKET_NAME, NB_REGION_ID, HF_TOKEN, SERVING_IMAGE
+# Optional env: SUBNET_ID, BUCKET_ID, PLATFORM, PRESET, PREFIX, TRIGGER_WORD,
+#               TRIGGER_CLASS, LORA_PATH,
+#               AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (enables "url" mode)
+set -euo pipefail
+
+: "${PARENT_ID:?set PARENT_ID to your Nebius project id}"
+: "${BUCKET_NAME:?set BUCKET_NAME to your Object Storage bucket}"
+: "${NB_REGION_ID:?set NB_REGION_ID, e.g. eu-north1 or us-central1}"
+: "${HF_TOKEN:?FLUX.2-dev is gated - export an HF token whose account accepted the model license}"
+: "${SERVING_IMAGE:?e.g. cr.<region>.nebius.cloud/<registry-id>/flux-avatar-serving:v1}"
+
+PLATFORM="${PLATFORM:-gpu-h200-sxm}"
+PRESET="${PRESET:-1gpu-16vcpu-200gb}"
+PREFIX="${PREFIX:-flux-avatar}"
+TRIGGER_WORD="${TRIGGER_WORD:-TOK4ME}"
+TRIGGER_CLASS="${TRIGGER_CLASS:-person}"
+LORA_PATH="${LORA_PATH:-/workspace/bucket/${PREFIX}/serving/lora.safetensors}"
+
+SUBNET_ID="${SUBNET_ID:-$(nebius vpc subnet list --parent-id "$PARENT_ID" --format json | jq -r '.items[0].metadata.id')}"
+BUCKET_ID="${BUCKET_ID:-$(nebius storage bucket get-by-name --name "$BUCKET_NAME" --parent-id "$PARENT_ID" --format json | jq -r '.metadata.id')}"
+
+EP_NAME="flux-avatar-ep-$(date +%Y%m%d%H%M%S)"
+
+# One bearer token passes both auth layers: the platform proxy (--auth token)
+# and the fail-closed in-container check (API_TOKEN). Stored locally with
+# 600 permissions; never commit or echo it.
+AUTH_TOKEN="$(openssl rand -hex 32)"
+umask 077
+printf '%s' "$AUTH_TOKEN" > ./endpoint.token
+echo "Bearer token written to ./endpoint.token (chmod 600)."
+
+# NOTE: --env values are visible to project members via `nebius ai endpoint
+# get`. In shared projects use MysteryBox secrets: --token-secret for the
+# platform token and --env-secret for HF_TOKEN / API_TOKEN / AWS keys.
+EXTRA_ARGS=()
+if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  EXTRA_ARGS+=(
+    --env "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+    --env "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+    --env "S3_BUCKET=${BUCKET_NAME}"
+    --env "S3_ENDPOINT_URL=https://storage.${NB_REGION_ID}.nebius.cloud"
+    --env "S3_PREFIX=${PREFIX}/generated/"
+  )
+  echo "Object Storage credentials detected: response_format=url enabled."
+else
+  echo "No AWS credentials in env: endpoint will support base64 responses only."
+fi
+
+echo "Creating endpoint ${EP_NAME} (create blocks until scheduled)..."
+nebius ai endpoint create \
+  --name "$EP_NAME" \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --image "$SERVING_IMAGE" \
+  --platform "$PLATFORM" \
+  --preset "$PRESET" \
+  --disk-size 300Gi \
+  --container-port 8000 \
+  --auth token \
+  --token "$AUTH_TOKEN" \
+  --volume "${BUCKET_ID}:/workspace/bucket:ro" \
+  --env "MODEL_ID=black-forest-labs/FLUX.2-dev" \
+  --env "LORA_PATH=${LORA_PATH}" \
+  --env "TRIGGER_WORD=${TRIGGER_WORD}" \
+  --env "TRIGGER_CLASS=${TRIGGER_CLASS}" \
+  --env "HF_TOKEN=${HF_TOKEN}" \
+  --env "API_TOKEN=${AUTH_TOKEN}" \
+  ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+
+EP_ID=$(nebius ai endpoint get-by-name --parent-id "$PARENT_ID" \
+  --name "$EP_NAME" --format json | jq -r '.metadata.id')
+cat <<EOF
+
+Endpoint : $EP_NAME
+ID       : $EP_ID
+
+Cold start is ~15-30 minutes (image pull + ~90 GB model download + load).
+Poll until state=RUNNING, then until /healthz reports ready=true:
+
+  nebius ai endpoint get $EP_ID --format json | jq -r .status.state
+  EP_URL=\$(nebius ai endpoint get $EP_ID --format json | jq -r '.status.public_endpoints[0]')
+  curl -s "\$EP_URL/healthz" -H "Authorization: Bearer \$(cat ./endpoint.token)"
+
+IMPORTANT: the HTTPS hostname in .status.public_endpoints[0] changes every
+time the endpoint is stopped and started again - always re-resolve it, never
+hardcode it.
+
+Smoke test (base64 response decoded to out.png):
+
+  curl -s -X POST "\$EP_URL/generate" \\
+    -H "Authorization: Bearer \$(cat ./endpoint.token)" \\
+    -H "Content-Type: application/json" \\
+    -d '{"prompt": "${TRIGGER_WORD} ${TRIGGER_CLASS}, studio portrait, natural skin texture", "seed": 42}' \\
+    | python3 -c 'import base64, json, sys; open("out.png", "wb").write(base64.b64decode(json.load(sys.stdin)["image_base64"]))'
+
+Verify auth fails closed (expect 401):
+
+  curl -s -o /dev/null -w '%{http_code}\n' -X POST "\$EP_URL/generate" -d '{}'
+
+The endpoint bills per second while RUNNING. Stop it when idle - it keeps its
+ID, token, and adapter, and restarts in ~15-30 min:
+
+  nebius ai endpoint stop $EP_ID
+  nebius ai endpoint start $EP_ID
+EOF

--- a/training/flux-subject-lora-avatar/serving/server.py
+++ b/training/flux-subject-lora-avatar/serving/server.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Minimal FLUX.2-dev + LoRA image-generation server for a Nebius Serverless
+AI Endpoint.
+
+- loads black-forest-labs/FLUX.2-dev (gated: HF_TOKEN required) with the
+  diffusers Flux2Pipeline, applies your subject LoRA via load_lora_weights
+  (PEFT-backed) in a background thread, and reports readiness on /healthz
+- POST /generate renders one image; auth is fail-closed bearer-token:
+  if API_TOKEN / API_TOKEN_FILE is not configured, every request is refused.
+  (The platform `--auth token` proxy is the first auth layer; this is
+  defense in depth inside the container.)
+- response_format "base64" returns the PNG inline; "url" uploads it to
+  Object Storage via boto3 and returns a presigned URL - required for
+  ChatGPT Actions, whose responses are truncated at roughly 100 KB.
+
+Environment:
+  MODEL_ID        base model (default black-forest-labs/FLUX.2-dev)
+  LORA_PATH       path to the adapter .safetensors (e.g. on the bucket mount)
+  TRIGGER_WORD    optional; prepended as "<TRIGGER_WORD> <TRIGGER_CLASS>, "
+                  when the prompt does not already contain it
+  TRIGGER_CLASS   class noun used with TRIGGER_WORD (default "person")
+  API_TOKEN or API_TOKEN_FILE   bearer token for /generate (fail-closed)
+  S3_BUCKET, S3_ENDPOINT_URL, S3_PREFIX, URL_TTL_SECONDS,
+  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY   only needed for "url" mode
+"""
+import base64
+import hmac
+import io
+import os
+import secrets as pysecrets
+import threading
+import time
+import uuid
+from typing import Optional
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+MODEL_ID = os.environ.get("MODEL_ID", "black-forest-labs/FLUX.2-dev")
+LORA_PATH = os.environ.get("LORA_PATH", "")
+TRIGGER_WORD = os.environ.get("TRIGGER_WORD", "")
+TRIGGER_CLASS = os.environ.get("TRIGGER_CLASS", "person")
+S3_BUCKET = os.environ.get("S3_BUCKET", "")
+S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL", "")
+S3_PREFIX = os.environ.get("S3_PREFIX", "flux-avatar/generated/")
+URL_TTL = int(os.environ.get("URL_TTL_SECONDS", "3600"))
+
+app = FastAPI(title="flux-avatar-serving")
+
+_pipe = None
+_pipe_lock = threading.Lock()
+_state = {"ready": False, "error": None}
+
+
+def _load_pipeline():
+    global _pipe
+    try:
+        import torch
+        from diffusers import Flux2Pipeline
+
+        pipe = Flux2Pipeline.from_pretrained(MODEL_ID, torch_dtype=torch.bfloat16)
+        if LORA_PATH:
+            pipe.load_lora_weights(LORA_PATH)
+        pipe.to("cuda")
+        _pipe = pipe
+        _state["ready"] = True
+    except Exception as exc:  # surfaced via /healthz
+        _state["error"] = f"{type(exc).__name__}: {exc}"
+
+
+threading.Thread(target=_load_pipeline, daemon=True).start()
+
+
+def _expected_token() -> str:
+    token = os.environ.get("API_TOKEN", "")
+    token_file = os.environ.get("API_TOKEN_FILE", "")
+    if not token and token_file and os.path.exists(token_file):
+        with open(token_file, encoding="utf-8") as fh:
+            token = fh.read().strip()
+    return token
+
+
+def _check_auth(authorization: Optional[str]) -> None:
+    expected = _expected_token()
+    if not expected:
+        # Fail closed: an unconfigured server must not serve anyone.
+        raise HTTPException(503, "API_TOKEN not configured; refusing requests")
+    supplied = ""
+    if authorization and authorization.startswith("Bearer "):
+        supplied = authorization[len("Bearer "):].strip()
+    if not supplied or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(401, "missing or invalid bearer token")
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(min_length=1, max_length=2000)
+    width: int = 1024
+    height: int = 1024
+    steps: int = Field(default=28, ge=1, le=64)
+    guidance_scale: float = Field(default=4.0, ge=0.0, le=10.0)
+    seed: Optional[int] = Field(default=None, ge=0, lt=2**31)
+    response_format: str = "base64"  # "base64" | "url"
+
+
+@app.get("/healthz")
+def healthz():
+    return {
+        "ready": _state["ready"],
+        "error": _state["error"],
+        "model": MODEL_ID,
+        "lora_loaded": _state["ready"] and bool(LORA_PATH),
+    }
+
+
+@app.post("/generate")
+def generate(req: GenerateRequest,
+             authorization: Optional[str] = Header(default=None)):
+    _check_auth(authorization)
+    if not _state["ready"]:
+        detail = "model is still loading"
+        if _state["error"]:
+            detail = f"model failed to load: {_state['error']}"
+        raise HTTPException(503, detail)
+    for name, value in (("width", req.width), ("height", req.height)):
+        if value % 64 != 0 or not 256 <= value <= 1536:
+            raise HTTPException(
+                400, f"{name} must be a multiple of 64 in [256, 1536]")
+    if req.response_format not in ("base64", "url"):
+        raise HTTPException(400, "response_format must be 'base64' or 'url'")
+    if req.response_format == "url" and not (S3_BUCKET and S3_ENDPOINT_URL):
+        raise HTTPException(
+            400, "url mode is not configured (S3_BUCKET / S3_ENDPOINT_URL)")
+
+    prompt = req.prompt
+    if TRIGGER_WORD and TRIGGER_WORD.lower() not in prompt.lower():
+        prompt = f"{TRIGGER_WORD} {TRIGGER_CLASS}, {prompt}"
+
+    seed = req.seed if req.seed is not None else pysecrets.randbelow(2**31)
+
+    import torch
+
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    started = time.time()
+    with _pipe_lock:  # one GPU - serialize generations
+        image = _pipe(
+            prompt=prompt,
+            width=req.width,
+            height=req.height,
+            num_inference_steps=req.steps,
+            guidance_scale=req.guidance_scale,
+            generator=generator,
+        ).images[0]
+    elapsed = round(time.time() - started, 1)
+
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    png = buf.getvalue()
+
+    if req.response_format == "base64":
+        return {
+            "image_base64": base64.b64encode(png).decode(),
+            "seed": seed,
+            "prompt": prompt,
+            "elapsed_seconds": elapsed,
+        }
+
+    import boto3
+
+    key = f"{S3_PREFIX}{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}.png"
+    s3 = boto3.client("s3", endpoint_url=S3_ENDPOINT_URL)
+    s3.put_object(Bucket=S3_BUCKET, Key=key, Body=png, ContentType="image/png")
+    url = s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": S3_BUCKET, "Key": key},
+        ExpiresIn=URL_TTL,
+    )
+    return {
+        "image_url": url,
+        "expires_in_seconds": URL_TTL,
+        "seed": seed,
+        "prompt": prompt,
+        "elapsed_seconds": elapsed,
+    }

--- a/training/flux-subject-lora-avatar/train.sh
+++ b/training/flux-subject-lora-avatar/train.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Launch FLUX.2-dev subject-LoRA training as a Nebius Serverless AI Job.
+#
+# Operational defaults below come from a validated production run:
+#   --preemptible            preemptible jobs schedule in ~90 s even when the
+#                            on-demand GPU pool is tight (and cost less)
+#   --restart-policy on-failure + checkpoint preseed = training resumes from
+#                            the latest saved step after a preemption
+#   --timeout 16h            the timeout is WALL CLOCK including preemption
+#                            restarts and the ~90 GB model fetch - budget
+#                            several times the pure training time (>= 12h)
+#   --disk-size 400Gi        FLUX.2 model reconstruction is disk-hungry;
+#                            TMPDIR and HF_HOME are redirected to /workspace
+#
+# Code-outside-image pattern: the ai-toolkit config and the entry script are
+# uploaded to Object Storage and read by the job, so you can iterate without
+# building any image.
+#
+# Required env: PARENT_ID, BUCKET_NAME, NB_REGION_ID, HF_TOKEN
+# Optional env: SUBNET_ID, BUCKET_ID, PLATFORM, PRESET, JOB_TIMEOUT, PREFIX,
+#               TRAIN_IMAGE, TRIGGER_WORD, WANDB_API_KEY, WANDB_ENTITY
+set -euo pipefail
+
+: "${PARENT_ID:?set PARENT_ID to your Nebius project id}"
+: "${BUCKET_NAME:?set BUCKET_NAME to your Object Storage bucket}"
+: "${NB_REGION_ID:?set NB_REGION_ID, e.g. eu-north1 or us-central1}"
+: "${HF_TOKEN:?FLUX.2-dev is gated - export an HF token whose account accepted the model license}"
+
+PLATFORM="${PLATFORM:-gpu-h200-sxm}"
+PRESET="${PRESET:-1gpu-16vcpu-200gb}"
+JOB_TIMEOUT="${JOB_TIMEOUT:-16h}"
+PREFIX="${PREFIX:-flux-avatar}"
+TRIGGER_WORD="${TRIGGER_WORD:-TOK4ME}"
+# Public ai-toolkit runtime image (MIT-licensed project). Pin a digest for
+# reproducible reruns: docker.io/ostris/aitoolkit@sha256:<digest>
+TRAIN_IMAGE="${TRAIN_IMAGE:-docker.io/ostris/aitoolkit:latest}"
+
+SUBNET_ID="${SUBNET_ID:-$(nebius vpc subnet list --parent-id "$PARENT_ID" --format json | jq -r '.items[0].metadata.id')}"
+BUCKET_ID="${BUCKET_ID:-$(nebius storage bucket get-by-name --name "$BUCKET_NAME" --parent-id "$PARENT_ID" --format json | jq -r '.metadata.id')}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUN_NAME="flux-avatar-$(date +%Y%m%d%H%M%S)"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+# ---- render the training config -------------------------------------------
+sed "s/__RUN_NAME__/${RUN_NAME}/g" "$HERE/train_config.yaml" > "$STAGE/train.yaml"
+# Guard: the trigger token must be set literally in the config (filename-based
+# trigger inference is a known footgun - it lowercases and strips digits).
+grep -q "trigger_word: \"${TRIGGER_WORD}\"" "$STAGE/train.yaml" || {
+  echo "ERROR: train_config.yaml trigger_word does not match TRIGGER_WORD=${TRIGGER_WORD}." >&2
+  echo "Edit the config (trigger_word + sample prompts) and your captions together." >&2
+  exit 1
+}
+
+# ---- render the in-job entry script ---------------------------------------
+cat > "$STAGE/entry.sh" <<'ENTRY'
+#!/bin/bash
+# In-job entry script. The job copies this file to local disk and execs it -
+# never run a long-lived script directly from the S3 mount (the FUSE mount can
+# return "Stale file handle" mid-run and crash-loop the job).
+set -eu
+export TMPDIR=/workspace/tmp HF_HOME=/workspace/hf-cache PYTHONUNBUFFERED=1
+BUCKET=/workspace/bucket
+DS="$BUCKET/__PREFIX__/dataset"
+OUT="$BUCKET/__PREFIX__/output/__RUN_NAME__"
+mkdir -p /workspace/tmp /workspace/hf-cache /workspace/work-dataset \
+         /workspace/output "$OUT"
+
+echo "== staging dataset to local disk =="
+# Per-file cat + size verify: plain cp can trip on S3-FUSE metadata refresh,
+# and the latent cache is written INTO the dataset folder, so training must
+# run from a local copy anyway.
+for f in "$DS"/*; do
+  b=$(basename "$f"); ok=0
+  for attempt in 1 2 3; do
+    if cat "$f" > "/workspace/work-dataset/$b" 2>/dev/null && \
+       [ "$(stat -c%s "$f")" = "$(stat -c%s "/workspace/work-dataset/$b")" ]; then
+      ok=1; break
+    fi
+    sleep 2
+  done
+  [ "$ok" = 1 ] || { echo "failed to stage $b after 3 tries"; exit 1; }
+done
+NI=$(ls /workspace/work-dataset | grep -c '\.jpg$' || true)
+NC=$(ls /workspace/work-dataset | grep -c '\.txt$' || true)
+echo "staged pairs: images=$NI captions=$NC"
+[ "$NI" -gt 0 ] && [ "$NI" = "$NC" ]
+
+# Resume after preemption/restart: preseed checkpoints saved by an earlier
+# attempt; ai-toolkit continues from the latest checkpoint it finds.
+if [ -n "$(ls -A "$OUT" 2>/dev/null)" ]; then
+  echo "== preseeding previous checkpoints (resume) =="
+  cp -r "$OUT"/. /workspace/output/ || true
+fi
+
+cp "$BUCKET/__PREFIX__/jobs/__RUN_NAME__/train.yaml" /workspace/train.yaml
+
+# The ai-toolkit image entrypoint location has moved between releases;
+# discover run.py rather than hardcoding a path.
+for c in /app/ai-toolkit /workspace/ai-toolkit /root/ai-toolkit /ai-toolkit /app /workspace; do
+  if [ -f "$c/run.py" ]; then cd "$c"; break; fi
+done
+test -f run.py
+echo "== ai-toolkit at $(pwd), starting training =="
+
+# Train on local disk, sync artifacts to the bucket in the background and once
+# more at the end - checkpoints survive preemption and timeouts this way.
+sync_out() {
+  ( cd /workspace/output 2>/dev/null || exit 0
+    find . -type f | while IFS= read -r f; do
+      d="$OUT/${f#./}"
+      if [ ! -f "$d" ] || [ "$(stat -c%s "$f")" != "$(stat -c%s "$d")" ]; then
+        mkdir -p "$(dirname "$d")" && cp -f "$f" "$d" && echo "[sync] $f"
+      fi
+    done ) || true
+}
+python -u run.py /workspace/train.yaml &
+TRAIN_PID=$!
+( while kill -0 "$TRAIN_PID" 2>/dev/null; do sleep 300; sync_out; done ) &
+SYNC_PID=$!
+RC=0
+wait "$TRAIN_PID" || RC=$?
+kill "$SYNC_PID" 2>/dev/null || true
+echo "== training exited rc=$RC, final sync =="
+sync_out
+echo "== done rc=$RC =="
+exit $RC
+ENTRY
+sed -i "s|__RUN_NAME__|${RUN_NAME}|g; s|__PREFIX__|${PREFIX}|g" "$STAGE/entry.sh"
+
+# ---- upload job assets ------------------------------------------------------
+aws --endpoint-url "https://storage.${NB_REGION_ID}.nebius.cloud" \
+  s3 cp --recursive "$STAGE/" "s3://${BUCKET_NAME}/${PREFIX}/jobs/${RUN_NAME}/"
+
+# ---- create the job ---------------------------------------------------------
+# NOTE: --env values are visible to project members via `nebius ai job get`.
+# In shared projects put HF_TOKEN / WANDB_API_KEY in a MysteryBox secret and
+# use --env-secret KEY=<secret-selector> instead.
+EXTRA_ARGS=()
+if [ -n "${WANDB_API_KEY:-}" ]; then
+  EXTRA_ARGS+=(--env "WANDB_API_KEY=${WANDB_API_KEY}")
+  [ -n "${WANDB_ENTITY:-}" ] && EXTRA_ARGS+=(--env "WANDB_ENTITY=${WANDB_ENTITY}")
+fi
+
+echo "Creating job ${RUN_NAME} (create blocks until the workload is scheduled)..."
+nebius ai job create \
+  --name "$RUN_NAME" \
+  --parent-id "$PARENT_ID" \
+  --subnet-id "$SUBNET_ID" \
+  --image "$TRAIN_IMAGE" \
+  --platform "$PLATFORM" \
+  --preset "$PRESET" \
+  --disk-size 400Gi \
+  --shm-size 16Gi \
+  --timeout "$JOB_TIMEOUT" \
+  --preemptible \
+  --restart-policy on-failure \
+  --env "HF_TOKEN=${HF_TOKEN}" \
+  ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
+  --volume "${BUCKET_ID}:/workspace/bucket:rw" \
+  --container-command bash \
+  --args "-c \"cat /workspace/bucket/${PREFIX}/jobs/${RUN_NAME}/entry.sh > /workspace/entry.sh && exec bash /workspace/entry.sh\""
+
+JOB_ID=$(nebius ai job get-by-name --parent-id "$PARENT_ID" --name "$RUN_NAME" \
+  --format json | jq -r '.metadata.id')
+cat <<EOF
+
+Run name : $RUN_NAME
+Job id   : $JOB_ID
+
+Monitor:
+  nebius ai job get $JOB_ID --format json | jq -r .status.state
+  nebius ai logs $JOB_ID --follow
+
+Artifacts land in:
+  s3://${BUCKET_NAME}/${PREFIX}/output/${RUN_NAME}/${RUN_NAME}/
+  (LoRA .safetensors checkpoints + sample image grids + the exact config)
+
+After it completes, delete the job to free quota:
+  nebius ai job delete $JOB_ID
+EOF

--- a/training/flux-subject-lora-avatar/train_config.yaml
+++ b/training/flux-subject-lora-avatar/train_config.yaml
@@ -1,0 +1,92 @@
+# ai-toolkit (https://github.com/ostris/ai-toolkit) config for a FLUX.2-dev
+# personal-subject LoRA. This recipe reproduces a validated run: rank 32,
+# lr 5e-5, EMA, caption dropout 0.10, qfloat8-quantized transformer,
+# 1200 steps (~3 s/step on one modern datacenter GPU).
+#
+# __RUN_NAME__ is substituted by train.sh at launch time.
+#
+# If you change the trigger token (TOK4ME), change it EVERYWHERE at once:
+# your captions (prepare_dataset.py --trigger), trigger_word below, and the
+# sample prompts. Case matters - never rely on filename-based inference.
+#
+# Capacity variant (won an internal 13-candidate identity bench on a B200,
+# needs ~180 GB VRAM because the transformer stays unquantized):
+#   network.linear/linear_alpha: 64, train.lr: 2.5e-5, train.steps: 1400,
+#   model.quantize: false, caption_dropout_rate: 0.08
+---
+job: extension
+config:
+  name: "__RUN_NAME__"
+  process:
+    - type: 'sd_trainer'
+      training_folder: "/workspace/output"
+      performance_log_every: 100
+      device: cuda:0
+      trigger_word: "TOK4ME"
+      logging:
+        log_every: 10
+        use_wandb: false          # set true + export WANDB_API_KEY in train.sh
+        project_name: "flux-avatar-lora"
+        run_name: "__RUN_NAME__"
+      network:
+        type: "lora"
+        linear: 32
+        linear_alpha: 32
+      save:
+        dtype: float16
+        save_every: 200           # intermediate checkpoints let the identity
+        max_step_saves_to_keep: 6 # gate pick the best step, not just the last
+      datasets:
+        - folder_path: "/workspace/work-dataset"
+          caption_ext: "txt"
+          caption_dropout_rate: 0.10
+          shuffle_tokens: false
+          cache_latents_to_disk: true   # writes into the dataset folder ->
+          resolution: [512, 768, 1024]  # train from a LOCAL copy, not the S3 mount
+      train:
+        batch_size: 1
+        steps: 1200
+        gradient_accumulation_steps: 1
+        train_unet: true
+        train_text_encoder: false
+        gradient_checkpointing: true
+        unload_text_encoder: true
+        cache_text_embeddings: true
+        timestep_type: "sigmoid"
+        noise_scheduler: "flowmatch"
+        optimizer: "adamw8bit"
+        lr: 5e-5
+        ema_config:
+          use_ema: true
+          ema_decay: 0.99
+        dtype: bf16
+      model:
+        name_or_path: "black-forest-labs/FLUX.2-dev"  # gated - HF_TOKEN required
+        arch: "flux2"
+        quantize: true
+        quantize_te: true
+        qtype: "qfloat8"
+        qtype_te: "qfloat8"
+      sample:
+        sampler: "flowmatch"
+        sample_every: 200
+        width: 1024
+        height: 1024
+        # Keep sample prompts identical across experiments so checkpoint grids
+        # are directly comparable. Match your caption style ("TOK4ME person, ...";
+        # adjust the class word to man/woman if that is what your captions use).
+        prompts:
+          - "photo of TOK4ME person, studio portrait, natural skin texture"
+          - "TOK4ME person, professional headshot, neutral background"
+          - "close-up portrait of TOK4ME person, soft window light"
+          - "TOK4ME person in everyday clothing, outdoor natural light"
+          - "TOK4ME person walking on a city street, documentary photo"
+          - "TOK4ME person seated at a cafe, natural candid photo"
+        neg: ""
+        seed: 42
+        walk_seed: true
+        guidance_scale: 4
+        sample_steps: 28
+meta:
+  name: "FLUX.2-dev personal subject LoRA"
+  version: '1.0'


### PR DESCRIPTION
## What this adds

`training/flux-subject-lora-avatar/` — a full-arc workflow example:

1. **Dataset** from your own photos: `prepare_dataset.py` face-checks (exactly one face), resizes, writes trigger-token captions (`TOK4ME person, ...`), and reserves held-out identity references that are never trained on. Includes a plain likeness/consent note.
2. **Training** on a Serverless AI Job with the public `ostris/aitoolkit` image (MIT-licensed project) — `train.sh` + `train_config.yaml` carry validated operational defaults: `--preemptible` + `--restart-policy on-failure` with checkpoint preseed so preempted runs resume, generous wall-clock timeout, 400Gi disk with `TMPDIR`/`HF_HOME` redirected, per-file dataset staging to local disk (S3-FUSE lessons), periodic checkpoint sync to the bucket. ~1–1.5 h on one modern GPU (~3 s/step, 1200 steps, incl. the ~90 GB model fetch).
3. **Identity gate** instead of eyeballing: `score_identity.py` (ArcFace vs the holdout refs) picks the winning checkpoint — the last step is often not the best.
4. **Serving**: clean-room minimal FastAPI app (`diffusers Flux2Pipeline` + PEFT `load_lora_weights`), fail-closed bearer auth, `/healthz` + `/generate` with `response_format: base64|url` (presigned Object Storage upload). `serve.sh` creates a private token-authenticated endpoint with an on-demand stop/start runbook (per-second billing, ~15–30 min cold start, ~12–45 s warm generation).
5. **LLM integration**: MCP server for Claude (status/start/stop/generate tools; resolves the endpoint URL at call time because the tunnel hostname changes on every stop/start) and a ChatGPT Custom GPT Action (`openapi.yaml` + instructions) using `response_format: url` — ChatGPT truncates Action responses at ~100 KB, so inline base64 can never work.

A troubleshooting table covers the failure modes hit in practice: `NotEnoughResources` (preemptible jobs vs on-demand endpoints, scheduling order), `TimeoutExceeded` math with preemption restarts, S3-FUSE stale-handle crash loops, stale endpoint hostnames after restart, and base64-vs-URL for Actions.

This distills a real validated end-to-end run (train -> ArcFace-gated checkpoint pick -> endpoint smoke incl. 401 auth matrix -> Claude/ChatGPT generation); the published version is fully generic — placeholder trigger token, bucket, project, and region.

## Verification done

- `python3 -m py_compile` on all four `.py` files; `bash -n` on both `.sh` files and the rendered in-job entry script; YAML parse checks on `train_config.yaml` and `chatgpt/openapi.yaml`
- MCP server passes a real stdio handshake + `tools/list` (4 tools) with dummy env vars
- `prepare_dataset.py` exercised end-to-end offline (`--no-face-check`): resize cap, default and sidecar captions, holdout split all correct
- `serving/server.py` auth paths exercised via FastAPI TestClient: no token configured -> 503 fail-closed, missing/wrong bearer -> 401, authed-but-unloaded -> 503, size/`response_format` validation -> 400
- Public facts verified: `ostris/aitoolkit` exists on Docker Hub, ai-toolkit is MIT and supports `arch: "flux2"` with `black-forest-labs/FLUX.2-dev`, `Flux2Pipeline` ships in diffusers >= 0.36.0
- No GPU training was run for this PR

## Review checklist (draft until checked)

- [ ] License check: ai-toolkit usage/attribution and the FLUX.2-dev gated-license wording read right
- [ ] Final sanitization eyeball: no personal/internal identifiers, buckets, IDs, hostnames, or tokens anywhere in the diff
- [ ] Recipe sanity: hyperparameters in `train_config.yaml` match what we want to publish as defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)