### PR TITLE
docs: add soft-surface washer pick community project

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ External examples and writeups from the community running serverless workloads o
 
 - 🤖 **Positronic + Nebius serverless workflows** — Convert datasets, train ACT/SmolVLA, and serve checkpoints as endpoints — all serverless on Nebius. — _by vertix_ · [💻 code](https://github.com/vertix/positronic-open/tree/add-nebius-workflows/workflows/nebius)
 - 🦾 **norma-core SmolVLA — Nebius fine-tune recipe** — Upstream recipe the [`robotics/smolva-ft-norma-core`](./robotics/smolva-ft-norma-core/) example mirrors. — _by norma-core_ · [💻 code](https://github.com/norma-core/norma-core/blob/main/software/ai/smolvla_py/nebius.md)
+- 🔩 **Soft-surface washer pick with Nebius Serverless AI Jobs** — A UR10e in Isaac Sim flips a flat washer off a compliant surface; 38 H100 Jobs co-optimize material × maneuver, ES-training checkpoints ride home base64-encoded in the job logs, and a CPU Endpoint serves the grasp-success scorer. — _by David Cox_ · [💻 code](https://github.com/robotcompanyDave/rc-nebius-challenge-2026-public) · [🎬 video](https://youtu.be/IAawtx7Snow)
 
 ### MLOps / Pipelines
 


### PR DESCRIPTION
Adds "Soft-surface washer pick with Nebius Serverless AI Jobs" to Awesome Community Projects, following the invitation to share Serverless AI Builders Challenge projects.

A flat washer lying face-down has nothing for a parallel-jaw gripper to grab. The project teaches a UR10e in Isaac Sim to flip the washer off a compliant surface — press one edge, the other tips up, pinch, lift — and uses Nebius Serverless AI Jobs for everything too heavy for one workstation:

- **Material × maneuver co-optimization** — 38 chained H100 Jobs, each sized ~14 min to fit the job window; winner was soft PU foam (~60 kPa / 10 mm) at 89.4 % ± 4.1 success, +20 pp over the incumbent surface.
- **Env-in-the-loop CEM tuning** — 17/18 picks under ±1.5 mm / ±20° jitter, zero flips, for ≈ $1.80 of compute.
- **Overnight evolution-strategies training** — model weights dumped base64 into the job logs every update, so the log line *is* the checkpoint and a killed job loses ≤ 1 update. Honest negative: the closed-loop residual policy reached only parity with the open-loop solution, which stays deployed.
- **CPU Serverless Endpoint** — FastAPI service for the grasp-success scorer (val AUC 0.823 on a self-generated 4,000-attempt dataset).

Project: https://github.com/robotcompanyDave/rc-nebius-challenge-2026-public
Video walkthrough (9 min): https://youtu.be/IAawtx7Snow

README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)